### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,8 @@ if (!isReleaseBuild()) {
                 url = 'https://central.sonatype.com/repository/maven-snapshots/'
 
                 credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+                    username = findProperty('ossrhUsername')
+                    password = findProperty('ossrhPassword')
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow triggered on push/PR to `master`
- Sets up Java 21 (Temurin) with Gradle caching via `gradle/actions/setup-gradle`
- Replaces the outdated Travis CI config (which used JDK 11)

## Test plan
- [ ] Verify the workflow runs successfully on the new branch
- [ ] Confirm build and tests pass in GitHub Actions