### PR TITLE
Align renovate config with docktape org standards

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "minimumReleaseAge": "30 days",
+  "schedule": ["on monday"],
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "enabled": true,
+    "schedule": ["at any time"]
+  },
+  "packageRules": [
+    {
+      "description": "Group all Gradle and Gradle wrapper updates",
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": "jvm-dependencies"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `schedule: ["on monday"]` and `minimumReleaseAge: "30 days"` to match the docktape private org config
- Add `vulnerabilityAlerts` block so security fixes bypass the schedule and age gate
- Add explicit `jvm-dependencies` group for Gradle and Gradle wrapper updates